### PR TITLE
added more specific rules around which functions need @JvmOverloads

### DIFF
--- a/src/test/kotlin/com/github/tbd54566975/tbddetektrules/JvmOverloadsAnnotationRuleTest.kt
+++ b/src/test/kotlin/com/github/tbd54566975/tbddetektrules/JvmOverloadsAnnotationRuleTest.kt
@@ -39,8 +39,7 @@ internal class JvmOverloadsAnnotationRuleTest(private val env: KotlinCoreEnviron
 
     @Test
     fun `doesn't report methods annotated with @JvmOverloads`() {
-        val code = """import org.jetbrains.kotlin.com.intellij.psi.JvmCommon
-
+        val code = """
         class A {
           @JvmOverloads
           fun foo(a: Int = 1) {
@@ -52,14 +51,51 @@ internal class JvmOverloadsAnnotationRuleTest(private val env: KotlinCoreEnviron
         findings shouldHaveSize 0
     }
 
-
-
   @Test
   fun `doesn't report methods annotated with fully qualified @kotlinJvmJvmOverloads`() {
     val code = """
       class A {
         @kotlin.jvm.JvmOverloads
         fun foo(a: Int = 1) {
+
+        }
+      }
+    """
+    val findings = JvmOverloadsAnnotationRule(Config.empty).compileAndLintWithContext(env, code)
+    findings shouldHaveSize 0
+  }
+
+  @Test
+  fun `doesn't report methods inside an interface`() {
+    val code = """
+      interface A {
+        fun foo(a: Int = 1) {
+
+        }
+      }
+    """
+    val findings = JvmOverloadsAnnotationRule(Config.empty).compileAndLintWithContext(env, code)
+    findings shouldHaveSize 0
+  }
+
+  @Test
+  fun `doesn't report on abstract methods inside a concrete class`() {
+    val code = """
+      class A {
+        abstract fun foo(a: Int = 1) {
+
+        }
+      }
+    """
+    val findings = JvmOverloadsAnnotationRule(Config.empty).compileAndLintWithContext(env, code)
+    findings shouldHaveSize 0
+  }
+
+  @Test
+  fun `doesn't report on abstract methods inside an abstract class`() {
+    val code = """
+      abstract class A {
+        abstract fun foo(a: Int = 1) {
 
         }
       }


### PR DESCRIPTION
# Overview
Edited the @JvmOverloads detekt ruleset to exclude linting on functions inside an interface and abstract functions, as these cannot have @JvmOverloads annotation

# Description
Applying this ruleset to our kotlin libraries will help make them compatible when using them in Java codebases, since the annotation is used to compile and expose overload methods. 

Related repo / issue [here](https://github.com/TBD54566975/web5-kt/issues/66)

# How Has This Been Tested?
Wrote unit tests against the updated ruleset.

# Checklist

Before submitting this PR, please make sure:

- [x] I have read the CONTRIBUTING document.
- [x] My code is consistent with the rest of the project 
- [x] I have tagged the relevant reviewers and/or interested parties
- [x] I have updated the READMEs and other documentation of affected packages

## References
See [this kotlin doc](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-overloads/) for more details on where `@JvmOverloads` should be used.